### PR TITLE
chore: remove node14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [16, 18]
     name: test - ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [16, 18]
     name: e2e - ${{ matrix.node }}
     env:
       DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres?schema=public"


### PR DESCRIPTION
```
┌──────────────────────────────────────────────┐
│    Prisma only supports Node.js >= 16.13.    │
│    Please upgrade your Node.js version.      │
└──────────────────────────────────────────────┘
```